### PR TITLE
Ensure the composer, IDRCloudClient, and examples use the same namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "autoload": {
         "psr-4": {
-            "IDRsolutions\\IDRCloudClient\\": "src/"
+            "IDRsolutions\\": "src/"
         }
     }
 }

--- a/src/IDRCloudClient.php
+++ b/src/IDRCloudClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace idrsolutions;
+namespace IDRsolutions;
 
 if (!defined('STDIN'))  define('STDIN', fopen('php://stdin', 'r'));
 

--- a/tests/Convert.php
+++ b/tests/Convert.php
@@ -2,7 +2,7 @@
 
 require_once __DIR__ . "/PATH/TO/vendor/autoload.php";
 
-use idrsolutions\IDRCloudClient;
+use IDRsolutions\IDRCloudClient;
 
 // Append INPUT_BUILDVU or INPUT_JPEDAL in the URL depending on which microservice you re using
 


### PR DESCRIPTION
Ensure the composer autoload config, IDRCloudClient class, and examples use the same IDRsolutions namespace.

'IDRsolutions' is being opted for over 'idrsolutions', both are valid, but in the examples of [PSR-4](https://www.php-fig.org/psr/psr-4/) the use of StudlyCaps/PascalCase for package is the preferred approach. See also the examples in the [PSR-12 coding standards](https://www.php-fig.org/psr/psr-12/).

The autoload configuration was likely introduced when converting the [buildvu-php-client](https://github.com/idrsolutions/buildvu-php-client), where there was a SubNamespace named 'BuildVuPhpClient' but the actual class was named 'Converter'. This meant a standard use statement was `use IDRsolutions\BuildVuPhpClient\Converter;`.
However, in the current configuration, there is no SubNamespace and the actual class was named 'IDRCloudClient' (similar to the previous SubNamespace), meaning its autoload use statement would have been `use IDRsolutions\IDRCloudClient \IDRCloudClient;`.

Note that the namespace was lowercase in the tests/Convert example, in order to match the class, but were not in our documentation ([this page](https://support.idrsolutions.com/buildvu/tutorials/cloud/languages/access-buildvu-using-php) for example).

This change will need a new major version for the client to be released (v5.0.0) as it is not a backwards compatible change, and will require users to update the use statement in their code. 

